### PR TITLE
Use dev builds of panel and bokeh

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,10 @@
 name: psy-vtk
 channels:
+  - bokeh/label/dev
   - conda-forge
 dependencies:
   - python=3.7
-  - panel
+  - bokeh
   - netcdf4
   - pyvista
   - psy-simple

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,5 @@ dependencies:
   - netcdf4
   - pyvista
   - psy-simple
+  - pyct
+  - pyviz_comms

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,6 @@ dependencies:
   - netcdf4
   - pyvista
   - psy-simple
-  - pyct
   - pyviz_comms
+  - pip:
+    - pyct

--- a/postBuild
+++ b/postBuild
@@ -1,1 +1,8 @@
+#!/bin/bash
+# Install panel from master branch to keep up with bug fixes
+git clone https://github.com/pyviz/panel.git
+mv panel .panel
+cd .panel
+python setup.py install
+cd ..
 python -m pip install . --no-deps --ignore-installed -vvv

--- a/postBuild
+++ b/postBuild
@@ -1,8 +1,8 @@
 #!/bin/bash
+python -m pip install . --no-deps --ignore-installed -vvv
 # Install panel from master branch to keep up with bug fixes
 git clone https://github.com/pyviz/panel.git
 mv panel .panel
 cd .panel
 python setup.py install
 cd ..
-python -m pip install . --no-deps --ignore-installed -vvv


### PR DESCRIPTION
`panel` and `bokeh` are a bit slow to publish releases - the dev builds are more stable than the current released versions of these packages for the VTK compatibility

I went ahead and [built an image for my fork](https://mybinder.org/v2/gh/banesullivan/psy-vtk/master) in case you want to make sure it works

If you make more of these PyVista-compatible binder's, then the [cookie-cutter](https://github.com/pyvista/cookiecutter-pyvista-binder) might help!